### PR TITLE
Add Prompt-Kit Primitives to AI SDKs and Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ APIs, SDKs, and underlying technologies for building AI-powered applications and
 |------|------|-------------|------|------|
 | DSPy | [GitHub](https://github.com/stanfordnlp/dspy) | Data-science pipelines & feature engineering | Clean API; easy to integrate; accelerates ML | Small community; minimal maintenance |
 | BAML | [GitHub](https://github.com/BoundaryML/baml) | Bayesian ML / AML framework | Strong uncertainty quantification; modern design | Steep learning curve; niche use-cases |
+| Prompt-Kit Primitives | [Prompt-Kit](https://www.prompt-kit.com/primitives) | Fullstack building blocks for AI applications | Pre-built UI components; Vercel AI SDK integration; easy installation via shadcn registry | Requires Vercel AI SDK; limited primitive selection currently |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Adds Prompt-Kit Primitives to the list of AI SDKs and frameworks in the README
- Highlights key features such as pre-built UI components, Vercel AI SDK integration, and easy installation via shadcn registry
- Notes current limitations including dependency on Vercel AI SDK and limited primitive selection

## Changes

### README Update
- Inserted a new entry for Prompt-Kit Primitives under the AI SDKs and frameworks table
- Provided a brief description and links to the Prompt-Kit website
- Included pros and cons to inform users about the toolkit's capabilities and constraints

## Test plan
- [x] Verified correct rendering of the new table row in the README
- [x] Confirmed link to Prompt-Kit website is accurate and functional
- [x] Checked formatting consistency with existing entries

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7bd01032-0b36-4a84-95a8-c5094f8bdcbb